### PR TITLE
gha: add action for draft releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @bulderbank/cloud will be requested for review
+# when someone opens a pull request.
+* @bulderbank/cloud

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug concerning the Bulder infrastructure
+labels: bug
+
+---
+
+# 🐛 Bug Report
+<!--
+*A clear and concise description of what the bug is and how the expected behavior/code should be.*
+-->
+
+
+## How to reproduce the bug
+<!--
+*Here you can write in freetext how to reproduce the bug*
+-->
+
+
+## Additional context
+<!--
+*Here you can add any addition context, such as links to forums and issue trackers.
+Basically anything that can help debugging and fixing this bug report*
+-->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: feature
+
+---
+
+# 👨‍🍳 Feature Request
+<!--
+*A clear and concise description of what you want to be added. Add any considered drawbacks.*
+-->
+
+
+## Alternatives you've considered
+<!--
+*A clear and concise description of any alternative solutions or features you've considered.*
+-->
+
+
+## Documentation, articles, links and others
+<!--
+*Here you can add documentation such as links and articles,
+maybe add some screenshots, sketches or a picture of whiteboard scribblings?*
+-->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+  Does this PR reference or resolve Issue?
+    Related: #000, #000
+    Resolves: #000, #000
+-->
+
+<!--
+  What was the motivation behind this change?
+-->
+
+
+
+### Documentation, links and more
+<!--
+  Here you can add documentation such as links and articles,
+  anything that was useful during the work on this PR.
+-->
+

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'maintenance'
+      - 'draft'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,30 +11,29 @@ jobs:
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'fmt'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'init'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Terraform Validate'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'validate'
-          args: '-var-file="dev.tfvars"'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
       - name: 'Terraform Plan'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'plan'
           args: '-var-file="dev.tfvars"'
         env:


### PR DESCRIPTION
<!--
  Does this PR reference or resolve Issue?
    Related: #000, #000
    Resolves: #000, #000
-->
<!--
  What was the motivation behind this change?
-->
- Add Github Action for creating draft github releases, with auto-generated release notes based on pull requests between releases.
- Add CODEOWNERS file for requiring review from team-cloud, also add templates for PRs and issues.
- Update the Github action to use Terraform v0.12.19

Using semantic versioning in git tags, will allow us to lock versions on Terraform modules like this:
```
source = "git::git@github.com: bulderbank/terraform-google-service-account?ref=v0.1.2"
```